### PR TITLE
 Refactors (mainly Utils.{map,filterResursive}), comments, cleanups

### DIFF
--- a/src/main/java/edu/berkeley/riselab/rlqopt/ExpressionList.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/ExpressionList.java
@@ -2,7 +2,7 @@ package edu.berkeley.riselab.rlqopt;
 
 import java.util.LinkedList;
 
-/** An expression is a tree with a operator and a sequence of other expressions */
+/** Convenience class to represent a list of expressions. */
 public class ExpressionList extends LinkedList<Expression> {
 
   // create it explicitly named

--- a/src/main/java/edu/berkeley/riselab/rlqopt/Operator.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/Operator.java
@@ -1,12 +1,15 @@
 package edu.berkeley.riselab.rlqopt;
 
-import edu.berkeley.riselab.rlqopt.relalg.*;
+import edu.berkeley.riselab.rlqopt.relalg.GroupByOperator;
+import edu.berkeley.riselab.rlqopt.relalg.ProjectOperator;
+import edu.berkeley.riselab.rlqopt.relalg.TableAccessOperator;
 import java.util.LinkedList;
+import java.util.List;
 
 /** Operator class- this class defines an abstract relational operator */
 public abstract class Operator {
 
-  public LinkedList<Operator> source; // data structure that holds the source
+  public List<Operator> source; // data structure that holds the source
   public OperatorParameters params;
 
   /** An operator takes as input a number of source operators. Throws an OperatorException */
@@ -16,7 +19,6 @@ public abstract class Operator {
 
     // init the operator
     this.source = new LinkedList<Operator>();
-
     for (Operator o : source) this.source.add(o);
 
     this.params = params;

--- a/src/main/java/edu/berkeley/riselab/rlqopt/OperatorParameters.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/OperatorParameters.java
@@ -19,4 +19,11 @@ public class OperatorParameters {
     this.expression = expression;
     this.secondary_expression = secondary_expression;
   }
+
+  @Override
+  public String toString() {
+    String s = expression.toString();
+    if (secondary_expression != null) s += " " + secondary_expression.toString();
+    return s + ";";
+  }
 }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/preopt/CascadedSelect.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/preopt/CascadedSelect.java
@@ -4,9 +4,14 @@ import edu.berkeley.riselab.rlqopt.Expression;
 import edu.berkeley.riselab.rlqopt.Operator;
 import edu.berkeley.riselab.rlqopt.OperatorException;
 import edu.berkeley.riselab.rlqopt.OperatorParameters;
-import edu.berkeley.riselab.rlqopt.relalg.*;
-import java.util.LinkedList;
+import edu.berkeley.riselab.rlqopt.relalg.SelectOperator;
 
+/**
+ * Transforms Select(a AND b AND ...) into a series of singleton selects, Select(a, Select(b, ...)).
+ *
+ * <p>This could be useful when the attributes reference different relations; after the
+ * transformation, the filters have the opportunity to be pushed down.
+ */
 public class CascadedSelect implements PreOptimizationRewrite {
 
   public CascadedSelect() {}
@@ -38,12 +43,7 @@ public class CascadedSelect implements PreOptimizationRewrite {
       return in;
     }
 
-    LinkedList<Operator> children = new LinkedList();
-
-    for (Operator child : in.source) children.add(apply(child));
-
-    in.source = children;
-
+    in.source = Utils.map(in.source, this::apply);
     return in;
   }
 }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/preopt/EagerSelectProject.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/preopt/EagerSelectProject.java
@@ -2,46 +2,29 @@ package edu.berkeley.riselab.rlqopt.preopt;
 
 import edu.berkeley.riselab.rlqopt.Attribute;
 import edu.berkeley.riselab.rlqopt.Operator;
-import edu.berkeley.riselab.rlqopt.relalg.*;
+import edu.berkeley.riselab.rlqopt.relalg.ProjectOperator;
+import edu.berkeley.riselab.rlqopt.relalg.SelectOperator;
+import edu.berkeley.riselab.rlqopt.relalg.TableAccessOperator;
 import java.util.LinkedList;
+import java.util.List;
 
 public class EagerSelectProject implements InitRewrite {
 
-  public EagerSelectProject() {}
+  private List<Operator> gatherSelectProject(Operator in) {
+    return Utils.filterRecursive(
+        in, op -> (op instanceof SelectOperator || op instanceof ProjectOperator));
+  }
 
   private Operator removeSelectProject(Operator in) {
-
-    if (in instanceof TableAccessOperator) return in;
-
     if (in instanceof SelectOperator || in instanceof ProjectOperator) {
       return removeSelectProject(in.source.get(0));
     }
-
-    LinkedList<Operator> children = new LinkedList();
-
-    for (Operator child : in.source) children.add(removeSelectProject(child));
-
-    in.source = children;
-
+    in.source = Utils.map(in.source, this::removeSelectProject);
     return in;
   }
 
-  private LinkedList<Operator> gatherSelectProject(Operator in) {
-
-    LinkedList<Operator> operators = new LinkedList();
-
-    if (in instanceof SelectOperator || in instanceof ProjectOperator) {
-      operators.add(in);
-    }
-
-    for (Operator child : in.source) operators.addAll(gatherSelectProject(child));
-
-    return operators;
-  }
-
   private boolean eligible(Operator in, Operator probe) {
-
-    if ((!(in instanceof TableAccessOperator))
+    if (!(in instanceof TableAccessOperator)
         || (!((probe instanceof SelectOperator) || (probe instanceof ProjectOperator)))) {
       return false;
     }
@@ -49,46 +32,42 @@ public class EagerSelectProject implements InitRewrite {
     LinkedList<Attribute> s_attrList = in.params.expression.getAllVisibleAttributes();
     LinkedList<Attribute> t_attrList = probe.params.expression.getAllVisibleAttributes();
 
-    for (Attribute s : s_attrList)
-      for (Attribute t : t_attrList) if (!s.relation.equals(t.relation)) return false;
+    for (Attribute s : s_attrList) {
+      for (Attribute t : t_attrList) {
+        if (!s.relation.equals(t.relation)) return false;
+      }
+    }
 
     return true;
   }
 
-  private Operator eagerEligible(Operator in, LinkedList<Operator> probe) {
-
+  private Operator eagerEligible(Operator in, List<Operator> probe) {
     if (!(in instanceof TableAccessOperator)) {
       return in;
     }
 
     Operator prev = in;
-    for (Operator p : probe)
+    for (Operator p : probe) {
       if (eligible(in, p)) {
-
         p.source.clear();
         p.source.add(prev);
         prev = p;
       }
+    }
 
     return prev;
   }
 
-  public Operator applyRecurse(Operator rtn, LinkedList<Operator> probes) {
-
-    LinkedList<Operator> children = new LinkedList();
-
+  private Operator applyRecurse(Operator rtn, List<Operator> probes) {
     if (rtn instanceof TableAccessOperator) return eagerEligible(rtn, probes);
-
+    LinkedList<Operator> children = new LinkedList<>();
     for (Operator child : rtn.source) children.add(applyRecurse(child, probes));
-
     rtn.source = children;
-
     return rtn;
   }
 
   public Operator apply(Operator in) {
-
-    LinkedList<Operator> probes = gatherSelectProject(in);
+    List<Operator> probes = gatherSelectProject(in);
     Operator rtn = removeSelectProject(in);
     return applyRecurse(rtn, probes);
   }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/preopt/FlattenJoin.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/preopt/FlattenJoin.java
@@ -4,7 +4,8 @@ import edu.berkeley.riselab.rlqopt.ExpressionList;
 import edu.berkeley.riselab.rlqopt.Operator;
 import edu.berkeley.riselab.rlqopt.OperatorException;
 import edu.berkeley.riselab.rlqopt.OperatorParameters;
-import edu.berkeley.riselab.rlqopt.relalg.*;
+import edu.berkeley.riselab.rlqopt.relalg.JoinOperator;
+import edu.berkeley.riselab.rlqopt.relalg.KWayJoinOperator;
 import java.util.LinkedList;
 
 public class FlattenJoin implements PreOptimizationRewrite {
@@ -64,12 +65,7 @@ public class FlattenJoin implements PreOptimizationRewrite {
       return in;
     }
 
-    LinkedList<Operator> children = new LinkedList();
-
-    for (Operator child : flattened.source) children.add(apply(child));
-
-    flattened.source = children;
-
+    flattened.source = Utils.map(flattened.source, this::apply);
     return flattened;
   }
 }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/preopt/Utils.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/preopt/Utils.java
@@ -1,0 +1,23 @@
+package edu.berkeley.riselab.rlqopt.preopt;
+
+import edu.berkeley.riselab.rlqopt.Operator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class Utils {
+  static List<Operator> map(List<Operator> in, Function<Operator, Operator> func) {
+    return in.stream().map(func).collect(Collectors.toList());
+  }
+
+  static List<Operator> filterRecursive(Operator in, Predicate<Operator> pred) {
+    LinkedList<Operator> operators = new LinkedList<>();
+    if (pred.test(in)) {
+      operators.add(in);
+    }
+    for (Operator child : in.source) operators.addAll(filterRecursive(child, pred));
+    return operators;
+  }
+}

--- a/src/test/java/edu/berkeley/riselab/rlqopt/CostTest.java
+++ b/src/test/java/edu/berkeley/riselab/rlqopt/CostTest.java
@@ -1,8 +1,7 @@
 package edu.berkeley.riselab.rlqopt;
 
-import edu.berkeley.riselab.rlqopt.opt.*;
-import edu.berkeley.riselab.rlqopt.preopt.*;
-import edu.berkeley.riselab.rlqopt.relalg.*;
+import edu.berkeley.riselab.rlqopt.opt.AttributeStatistics;
+import edu.berkeley.riselab.rlqopt.opt.CannotEstimateException;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;

--- a/src/test/java/edu/berkeley/riselab/rlqopt/PreoptTest.java
+++ b/src/test/java/edu/berkeley/riselab/rlqopt/PreoptTest.java
@@ -1,8 +1,16 @@
 package edu.berkeley.riselab.rlqopt;
 
 import edu.berkeley.riselab.rlqopt.opt.Planner;
-import edu.berkeley.riselab.rlqopt.preopt.*;
-import edu.berkeley.riselab.rlqopt.relalg.*;
+import edu.berkeley.riselab.rlqopt.preopt.CascadedSelect;
+import edu.berkeley.riselab.rlqopt.preopt.EagerSelectProject;
+import edu.berkeley.riselab.rlqopt.preopt.ExposeProjection;
+import edu.berkeley.riselab.rlqopt.preopt.FlattenJoin;
+import edu.berkeley.riselab.rlqopt.preopt.InitRewrite;
+import edu.berkeley.riselab.rlqopt.preopt.PreOptimizationRewrite;
+import edu.berkeley.riselab.rlqopt.relalg.GroupByOperator;
+import edu.berkeley.riselab.rlqopt.relalg.JoinOperator;
+import edu.berkeley.riselab.rlqopt.relalg.SelectOperator;
+import edu.berkeley.riselab.rlqopt.relalg.TableAccessOperator;
 import java.util.LinkedList;
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -233,7 +241,7 @@ public class PreoptTest extends TestCase {
     return scan_r;
   }
 
-  private OperatorParameters createNaturalJoin(Relation r, Relation s) throws OperatorException {
+  private OperatorParameters createNaturalJoin(Relation r, Relation s) {
     Expression conjunction = null;
 
     for (Expression er : r.getExpressionList()) {

--- a/src/test/java/edu/berkeley/riselab/rlqopt/RelAlgTest.java
+++ b/src/test/java/edu/berkeley/riselab/rlqopt/RelAlgTest.java
@@ -1,6 +1,8 @@
 package edu.berkeley.riselab.rlqopt;
 
-import edu.berkeley.riselab.rlqopt.relalg.*;
+import edu.berkeley.riselab.rlqopt.relalg.JoinOperator;
+import edu.berkeley.riselab.rlqopt.relalg.ProjectOperator;
+import edu.berkeley.riselab.rlqopt.relalg.TableAccessOperator;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;


### PR DESCRIPTION
/cc @sjyk 
* In a few places also s/LinkedList/List, as using a generic interface as
declaration (whereas on the right hand side of an assignment, one can
supply any impl class such as LinkedList, ArrayList) seems to be the
best practice in java.
* In many `assert*()` call sites, I exchanged the two arguments as the convention is `assert(expected, actual)`.