### PR TITLE
NN improvements, normalize labels, cache training data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.idea/
+.ipynb_checkpoints/

--- a/src/main/java/edu/berkeley/riselab/rlqopt/Expression.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/Expression.java
@@ -57,18 +57,19 @@ public class Expression {
     return new ExpressionList(this);
   }
 
-  public LinkedList<Attribute> getVisibleAttributes() {
-    LinkedList<Attribute> visibleAttrs = new LinkedList<Attribute>();
-
+  public LinkedList<Attribute> getVisibleAttributes(LinkedList<Attribute> visibleAttrs) {
     // base case
     if (this.op == null) {
       visibleAttrs.add(this.noop);
       return visibleAttrs;
     }
-
-    for (Expression e : children) visibleAttrs.addAll(e.getVisibleAttributes());
-
+    for (Expression e : children) e.getVisibleAttributes(visibleAttrs);
     return visibleAttrs;
+  }
+
+  public LinkedList<Attribute> getVisibleAttributes() {
+    LinkedList<Attribute> visibleAttrs = new LinkedList<Attribute>();
+    return getVisibleAttributes(visibleAttrs);
   }
 
   public HashSet<Attribute> getVisibleAttributeSet() {

--- a/src/main/java/edu/berkeley/riselab/rlqopt/ExpressionList.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/ExpressionList.java
@@ -28,11 +28,13 @@ public class ExpressionList extends LinkedList<Expression> {
     for (String attr : r) this.add(r.get(attr).getExpression());
   }
 
-  public LinkedList<Attribute> getAllVisibleAttributes() {
-
-    LinkedList<Attribute> visibleAttrs = new LinkedList<Attribute>();
-    for (Expression e : this) visibleAttrs.addAll(e.getVisibleAttributes());
-
+  public LinkedList<Attribute> getAllVisibleAttributes(LinkedList<Attribute> visibleAttrs) {
+    for (Expression e : this) e.getVisibleAttributes(visibleAttrs);
     return visibleAttrs;
+  }
+
+  public LinkedList<Attribute> getAllVisibleAttributes() {
+    LinkedList<Attribute> visibleAttrs = new LinkedList<>();
+    return getAllVisibleAttributes(visibleAttrs);
   }
 }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/Operator.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/Operator.java
@@ -44,28 +44,21 @@ public abstract class Operator {
     return keys;
   }
 
-  public LinkedList<Attribute> getVisibleAttributes() {
-
-    LinkedList<Attribute> visibleAttrs = new LinkedList<Attribute>();
-
+  public LinkedList<Attribute> getVisibleAttributes(LinkedList<Attribute> visibleAttrs) {
     if (this instanceof TableAccessOperator) {
-
-      visibleAttrs.addAll(params.expression.getAllVisibleAttributes());
-      return visibleAttrs;
-
+      return params.expression.getAllVisibleAttributes(visibleAttrs);
     } else if (this instanceof ProjectOperator) {
-
-      visibleAttrs.addAll(params.expression.getAllVisibleAttributes());
-      return visibleAttrs;
+      return params.expression.getAllVisibleAttributes(visibleAttrs);
     } else if (this instanceof GroupByOperator) {
-
-      visibleAttrs.addAll(params.secondary_expression.getAllVisibleAttributes());
-      return visibleAttrs;
+      return params.secondary_expression.getAllVisibleAttributes(visibleAttrs);
     }
-
-    for (Operator o : source) visibleAttrs.addAll(o.getVisibleAttributes());
-
+    for (Operator o : source) o.getVisibleAttributes(visibleAttrs);
     return visibleAttrs;
+  }
+
+  public LinkedList<Attribute> getVisibleAttributes() {
+    LinkedList<Attribute> visibleAttrs = new LinkedList<Attribute>();
+    return getVisibleAttributes(visibleAttrs);
   }
 
   // Validates the inputs to the operator

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/BaselineBushy.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/BaselineBushy.java
@@ -120,17 +120,8 @@ public class BaselineBushy implements CostCachingModule {
   }
 
   private Operator baseCase(HashMap<HashSet<Operator>, Operator> costMap, Operator in) {
-
-    for (HashSet<Operator> opList : costMap.keySet()) {
-
-      HashSet<Operator> childOps = new HashSet();
-
-      for (Operator child : in.source) childOps.add(child);
-
-      if (childOps.equals(opList)) return costMap.get(opList);
-    }
-
-    return null;
+    HashSet<Operator> childOps = new HashSet<>(in.source);
+    return costMap.get(childOps);
   }
 
   private HashMap<HashSet<Operator>, Operator> dynamicProgram(
@@ -171,7 +162,6 @@ public class BaselineBushy implements CostCachingModule {
           if ((isSubList(joinedAttributes1, left) && isSubList(joinedAttributes2, right))
               || (isSubList(joinedAttributes2, left) && isSubList(joinedAttributes1, right))) {
             OperatorParameters params = new OperatorParameters(e.getExpressionList());
-            
             JoinOperator cjv = new JoinOperator(params, op1, op2);
             result.put(union, greatest(result, c, union, cjv));
 

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/DataNormalizer.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/DataNormalizer.java
@@ -1,0 +1,44 @@
+package edu.berkeley.riselab.rlqopt.opt.learning;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.preprocessor.NormalizerStandardize;
+
+public class DataNormalizer {
+
+  private static NormalizerStandardize normalizer = null;
+  private static INDArray lablesMean;
+  private static INDArray lablesStd;
+
+  /** In-place, returns the updated data. */
+  public static INDArray transformFeature(INDArray data) {
+    return data;
+    //    assert normalizer != null;
+    //    normalizer.transform(data);
+    //    return data;
+  }
+
+  public static void normalize(DataSet dataSet) {
+    INDArray labels = dataSet.getLabels();
+    lablesMean = labels.mean(0);
+    lablesStd = labels.std(0);
+    lablesStd.addi(1e-6);
+    labels.subi(lablesMean).divi(lablesStd);
+    dataSet.setLabels(labels);
+
+    //    assert normalizer == null;
+    //    normalizer = new NormalizerStandardize();
+    //     Transform the labels (costs) too.
+    //    normalizer.fitLabel(true);
+    //    normalizer.fit(dataSet);
+    //    normalizer.transform(dataSet);
+  }
+
+  /** In-place, returns the updated data. */
+  public static INDArray revertLabel(INDArray data) {
+    return data.muli(lablesStd).addi(lablesMean);
+    //    assert normalizer != null;
+    //    normalizer.revertLabels(data);
+    //    return data;
+  }
+}

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/ModelTrainer.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/ModelTrainer.java
@@ -1,15 +1,15 @@
 package edu.berkeley.riselab.rlqopt.opt.learning;
 
 import edu.berkeley.riselab.rlqopt.Database;
-import java.io.*;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
-import org.nd4j.linalg.learning.config.Sgd;
+import org.nd4j.linalg.learning.config.Adam;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 public class ModelTrainer {
@@ -18,17 +18,15 @@ public class ModelTrainer {
 
   public ModelTrainer(Database db) {
     int numInput = db.getNumAttributes() * 4 + 2;
-
     int numOutputs = 1;
     int nHidden = 128;
-    double learningRate = 0; // 1e-10;
 
     this.net =
         new MultiLayerNetwork(
             new NeuralNetConfiguration.Builder()
                 .seed(12345)
                 .weightInit(WeightInit.XAVIER)
-                //.updater(new Sgd(0.0))
+                .updater(new Adam())
                 .list()
                 .layer(
                     0,
@@ -41,14 +39,14 @@ public class ModelTrainer {
                     1,
                     new DenseLayer.Builder()
                         .nIn(nHidden)
-                        .nOut(nHidden/2)
+                        .nOut(nHidden / 2)
                         .activation(Activation.SIGMOID)
                         .build())
                 .layer(
                     2,
                     new OutputLayer.Builder(LossFunctions.LossFunction.L1)
                         .activation(Activation.IDENTITY)
-                        .nIn(nHidden/2)
+                        .nIn(nHidden / 2)
                         .nOut(numOutputs)
                         .build())
                 .pretrain(false)
@@ -57,22 +55,15 @@ public class ModelTrainer {
   }
 
   public MultiLayerNetwork train(DataSetIterator iterator) {
-
     net.init();
+    net.setListeners(new ScoreIterationListener(10));
 
     System.out.println(net.getUpdater());
 
-    // Train the network on the full data set, and evaluate in periodically
-    for (int i = 0; i < 10000; i++) {
-
-      System.out.println("Iteration: " + i);
-
+    // Epochs.
+    for (int i = 0; i < 5000; i++) {
       iterator.reset();
-
-      if (iterator.hasNext()) {
-        iterator.next();
-        net.fit(iterator);
-      }
+      net.fit(iterator);
     }
 
     return net;

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TDJoinExecutor.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TDJoinExecutor.java
@@ -163,7 +163,6 @@ public class TDJoinExecutor implements PlanningModule {
 
   public HashSet<Operator> TDMerge(HashSet<Operator> relations, CostModel c, Operator in)
       throws OperatorException {
-
     double minCost = Double.MAX_VALUE;
     Operator[] pairToJoin = new Operator[3];
     HashSet<Operator> rtn = (HashSet) relations.clone();
@@ -203,9 +202,10 @@ public class TDJoinExecutor implements PlanningModule {
           TrainingDataPoint tpd =
               new TrainingDataPoint(currentPair, 0.0, 0.0, (double) relations.size());
           INDArray input = tpd.featurizeND4j(db, c);
-          INDArray out = net.output(input, false);
-          cost = out.getDouble(0);
 
+          INDArray out =
+              DataNormalizer.revertLabel(net.output(DataNormalizer.transformFeature(input), false));
+          cost = out.getDouble(0);
         } else {
           cost = c.estimate(cjv).operatorIOcost;
         }

--- a/src/test/java/edu/berkeley/riselab/rlqopt/DoExperiments.java
+++ b/src/test/java/edu/berkeley/riselab/rlqopt/DoExperiments.java
@@ -165,9 +165,16 @@ public class DoExperiments extends TestCase {
         new IMDBWorkloadGenerator(
             "schematext.sql", "imdb_tables.txt", "join-order-benchmark/queries/queries.sql");
 
+    final int numTraining = 50;
+    final int numTesting = 50;
+
+    // When non-null: load from this file without re-generation, or generate once and persist it.
+    // Pass null to disable this caching behavior.
+    String trainingDataPath = "job-" + numTraining + ".dat";
+
     LinkedList<Planner> planners = new LinkedList<>();
-    //planners.add(new NoPlanner());
-    planners.add(new RLQOpt(workload));
+    planners.add(new NoPlanner());
+    planners.add(new RLQOpt(workload, trainingDataPath));
     planners.add(new PostgresBushyPlanner());
     planners.add(new PostgresPlanner());
     planners.add(new RightDeepPlanner());
@@ -176,14 +183,14 @@ public class DoExperiments extends TestCase {
     planners.add(new QuickPickPlanner(1));
 
     //Experiment e = new Experiment(workload, 90, 113, planners);
-    Experiment e = new Experiment(workload,50, 50, planners);
+    Experiment e = new Experiment(workload,numTraining, numTesting, planners);
     e.train();
     e.run();
 
-    System.out.print("Improvement: ");
-    printSorted(e.getBaselineImprovement());
     System.out.println("Per query improvement: ");
     printPerQuery(e.getPerQueryImprovement());
+    System.out.print("Improvement: ");
+    printSorted(e.getBaselineImprovement());
     System.out.print("Planning latency: ");
     Map<Planner, Double> latencies = e.getBaselineLatency();
     printSorted(latencies);


### PR DESCRIPTION
NN improvements, normalize labels, cache training data.

Before:
```
Improvement: {greedy=17.76429408166907, learning=17.76534553322213,
left-deep=18.117042884611976, postgres-bushy=17.76429408166907,
quickpick-1=18.47187120742421, quickpick-1000=17.77429549664726,
right-deep=17.850919920465675}

Planning latency: {greedy=1.5484266399999997, learning=29.514439200000005,
left-deep=13.562378719999996, postgres-bushy=573.01343416,
quickpick-1=0.24402167999999996, quickpick-1000=75.61493390000001,
right-deep=13.082264160000001}
```

After this change:
```
Improvement: {greedy=17.76429408166907, learning=17.765249401614895, 
left-deep=18.117042884611976, postgres-bushy=17.76429408166907, 
quickpick-1=18.47187120742421, quickpick-1000=17.77429549664726, 
right-deep=17.850919920465675}

Planning latency: {greedy=1.2701428, learning=31.190809079999994, 
left-deep=9.337870679999998, postgres-bushy=339.36407068, 
quickpick-1=0.15194283999999997, quickpick-1000=56.60248427999999, 
right-deep=8.67188534}
```

Details:
* Training changes: use Adam; 5k epochs; full-batch training, i.e., each
batch == whole dataset (3000+ examples).  Use dl4j's reporting tool to
monitor loss.
* Cache training data.  Otherwise re-generation is very slow.
  * job-50.dat: unnormalized training data from JOB (3000+ examples from
  50 training queries)
* Normalize labels, so the scaling trick is gone.
  * DataNormalizer contains some commented out code which normalizes
  both features and labels.  In my testing, normalizing only labels
  gives better performance than normalizing both, likely because all
  features are 1-hot.

* Minor simplification in BaselineBushy

* Optimize various getVisibileAttributes(). Was showing up as hotspots in the
  profiler due to redundant object
    creation.
