### PR TITLE
Speed up inference on Mac by ~3x

### DIFF
--- a/src/main/java/edu/berkeley/riselab/rlqopt/cost/CostModel.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/cost/CostModel.java
@@ -35,7 +35,8 @@ public interface CostModel {
     System.out.println(treeMap);
   }
 
-  default double cardinality(Attribute a) {
-    return 1.0;
+  default float cardinality(Attribute a) {
+    return 1.0f;
   }
+
 }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/cost/DiskCostModel.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/cost/DiskCostModel.java
@@ -90,7 +90,7 @@ public class DiskCostModel implements CostModel {
     this.handleSelections = handleSelections;
   }
 
-  public double cardinality(Attribute a) {
+  public float cardinality(Attribute a) {
     return cardinality.get(a.relation);
   }
 

--- a/src/main/java/edu/berkeley/riselab/rlqopt/cost/InMemoryCostModel.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/cost/InMemoryCostModel.java
@@ -5,7 +5,14 @@ import edu.berkeley.riselab.rlqopt.Database;
 import edu.berkeley.riselab.rlqopt.Expression;
 import edu.berkeley.riselab.rlqopt.Operator;
 import edu.berkeley.riselab.rlqopt.Relation;
-import edu.berkeley.riselab.rlqopt.relalg.*;
+import edu.berkeley.riselab.rlqopt.relalg.CartesianOperator;
+import edu.berkeley.riselab.rlqopt.relalg.GroupByOperator;
+import edu.berkeley.riselab.rlqopt.relalg.HashJoinOperator;
+import edu.berkeley.riselab.rlqopt.relalg.IndexJoinOperator;
+import edu.berkeley.riselab.rlqopt.relalg.JoinOperator;
+import edu.berkeley.riselab.rlqopt.relalg.ProjectOperator;
+import edu.berkeley.riselab.rlqopt.relalg.SelectOperator;
+import edu.berkeley.riselab.rlqopt.relalg.TableAccessOperator;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
@@ -14,15 +21,10 @@ import java.util.Scanner;
 
 public class InMemoryCostModel implements CostModel {
 
-  private double defaultSelectivity = 0.1;
   private HashMap<Relation, Long> cardinality;
   private HashMap<HashSet<Relation>, Long> pairs;
   private HashMap<String, Long> predicates;
   public boolean handleSelections = false;
-
-  public InMemoryCostModel(HashMap<Relation, Long> cardinality) {
-    this.cardinality = cardinality;
-  }
 
   public InMemoryCostModel(Database db, String filename) {
     if (System.getProperty("hasSelection") != null) {
@@ -92,7 +94,7 @@ public class InMemoryCostModel implements CostModel {
     this.handleSelections = handleSelections;
   }
 
-  public double cardinality(Attribute a) {
+  public float cardinality(Attribute a) {
     return cardinality.get(a.relation);
   }
 
@@ -142,8 +144,6 @@ public class InMemoryCostModel implements CostModel {
     long cartCard = cardinality.get(el) * cardinality.get(er);
     long pairCard = pairs.get(rels);
     double rf = (pairCard + 0.) / cartCard;
-
-    JoinOperator jop = (JoinOperator) in;
 
     return (long) (rf * (countl * countr));
   }
@@ -228,4 +228,5 @@ public class InMemoryCostModel implements CostModel {
 
     return runningCost;
   }
+
 }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/CostCache.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/CostCache.java
@@ -10,7 +10,7 @@ public class CostCache {
 
   private static final boolean disableCaching = true;
 
-  private Map<String, Double> costCache = new HashMap<>();
+  private Map<String, Float> costCache = new HashMap<>();
   private Map<String, Long> cardCache = new HashMap<>();
 
   // Cache hit statistics for debugging.  Only for IO estimate.
@@ -21,17 +21,17 @@ public class CostCache {
     System.out.println("num hits " + numHits + " total " + numTotal);
   }
 
-  public double getOrComputeIOEstimate(Operator op, CostModel c, String plannerName) {
+  public float getOrComputeIOEstimate(Operator op, CostModel c, String plannerName) {
     if (disableCaching) {
-      return (double) c.estimate(op, plannerName).operatorIOcost;
+      return (float) c.estimate(op, plannerName).operatorIOcost;
     }
 
     ++numTotal;
     String opHash = op.toString();
 
-    double cost;
+    float cost;
     if (!costCache.containsKey(opHash)) {
-      cost = (double) c.estimate(op, plannerName).operatorIOcost;
+      cost = (float) c.estimate(op, plannerName).operatorIOcost;
       costCache.put(opHash, cost);
     } else {
       cost = costCache.get(opHash);
@@ -41,7 +41,7 @@ public class CostCache {
     return cost;
   }
 
-  public double getOrComputeCardinality(Operator op, CostModel c, String plannerName) {
+  public float getOrComputeCardinality(Operator op, CostModel c, String plannerName) {
     if (disableCaching) {
       return c.estimate(op, plannerName).resultCardinality;
     }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TDJoinSampler.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TDJoinSampler.java
@@ -124,7 +124,7 @@ public class TDJoinSampler extends PlanningModule {
         for (TrainingDataPoint t : localData) {
           // Use log() since it's normal for costs to vary from 10^5 to 10^11.  This significantly
           // reduces the optimization difficulty during training.
-          t.cost = Math.log(t.cost);
+          t.cost = (float) Math.log(t.cost);
           trainingData.add(t);
         }
 
@@ -255,7 +255,7 @@ public class TDJoinSampler extends PlanningModule {
 
           // exploration
           // System.out.println(rand.nextGaussian());
-          double cost = costCache.getOrComputeIOEstimate(baseline, c, this.name);
+          float cost = costCache.getOrComputeIOEstimate(baseline, c, this.name);
 
           Operator[] trainingToJoin = new Operator[4];
           trainingToJoin[0] = i;
@@ -266,7 +266,7 @@ public class TDJoinSampler extends PlanningModule {
           if (relations.size() <= 10)
             localData.add(
                 new TrainingDataPoint(
-                    trainingToJoin, cost, indicator + 0.0, relations.size() + 0.0));
+                    trainingToJoin, cost, (float) indicator , (float) relations.size()));
 
           // System.out.println(i + "," + j + " "+ indicator+ "=>" + cost);
 

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TrainingDataGenerator.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TrainingDataGenerator.java
@@ -88,18 +88,18 @@ public class TrainingDataGenerator {
     int p = 0;
 
     for (TrainingDataPoint tr : planner.getTrainingData()) {
-      Double[] vector = tr.featurize(db, c);
+      float[] vector = tr.featurize(db, c);
       p = vector.length;
 
       float[] xBuffer = new float[p - 1];
 
-      for (int ind = 0; ind < vector.length - 1; ind++) xBuffer[ind] = vector[ind].floatValue();
+      for (int ind = 0; ind < vector.length - 1; ind++) xBuffer[ind] = vector[ind];
 
       float[] yBuffer = new float[1];
 
-      if (Double.isInfinite(vector[vector.length - 1].floatValue())) continue;
+      if (Double.isInfinite(vector[vector.length - 1])) continue;
 
-      yBuffer[0] = vector[vector.length - 1].floatValue();
+      yBuffer[0] = vector[vector.length - 1];
 
       trainingExamples.add(Nd4j.create(xBuffer, new int[] {1, p - 1}));
       reward.add(Nd4j.create(yBuffer, new int[] {1, 1}));

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TrainingDataPoint.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/learning/TrainingDataPoint.java
@@ -13,12 +13,13 @@ import org.nd4j.linalg.factory.Nd4j;
 public class TrainingDataPoint {
 
   public Operator[] oplist;
-  public Double cost = 0.0;
-  public Double gcost = 0.0;
-  public Double size = 0.0;
+  public float cost = 0.0f;
+  public float gcost = 0.0f;
+  public float size = 0.0f;
 
   private static boolean selectivityScaling = false;
   private static boolean queryGraphFeatures = true;
+
   static {
     if (System.getProperty("selScaling") != null) {
       selectivityScaling = Boolean.valueOf(System.getProperty("selScaling"));
@@ -30,12 +31,12 @@ public class TrainingDataPoint {
     System.out.println("queryGraphFeatures = " + queryGraphFeatures);
   }
 
-  public TrainingDataPoint(Operator[] oplist, Double cost) {
+  public TrainingDataPoint(Operator[] oplist, float cost) {
     this.oplist = oplist;
     this.cost = cost;
   }
 
-  public TrainingDataPoint(Operator[] oplist, Double cost, Double greedyCost, Double size) {
+  public TrainingDataPoint(Operator[] oplist, float cost, float greedyCost, float size) {
     this.oplist = oplist;
     this.cost = cost;
     this.size = size;
@@ -46,8 +47,7 @@ public class TrainingDataPoint {
     return Arrays.toString(oplist) + " => " + cost;
   }
 
-  private HashMap<Attribute, Double> calculateSelCardinality(
-      Database db, Operator in, CostModel c) {
+  private HashMap<Attribute, Float> calculateSelCardinality(Database db, Operator in, CostModel c) {
 
     HashMap<Attribute, Long> selCard = new HashMap<>();
 
@@ -58,43 +58,43 @@ public class TrainingDataPoint {
     }
 
     LinkedList<Attribute> allAttributes = db.getAllAttributes();
-    HashMap<Attribute, Double> rtn = new HashMap<>();
+    HashMap<Attribute, Float> rtn = new HashMap<>();
 
     for (Attribute a : allAttributes) {
 
-      if (selCard.containsKey(a)) rtn.put(a, (selCard.get(a) + 0.0) / c.cardinality(a));
+      if (selCard.containsKey(a)) rtn.put(a, (float) selCard.get(a) / c.cardinality(a));
     }
 
     return rtn;
   }
 
-  public Double[] featurize(Database db, CostModel c) {
+  public float[] featurize(Database db, CostModel c) {
 
     LinkedList<Attribute> allAttributes = db.getAllAttributes();
-    HashMap<Attribute, Double> cardMap = new HashMap();
+    HashMap<Attribute, Float> cardMap = new HashMap();
 
     if (selectivityScaling) cardMap = calculateSelCardinality(db, oplist[3], c);
 
     int n = allAttributes.size();
 
-    Double[] vector = new Double[n * 3 + 4];
-    for (int i = 0; i < n * 3; i++) vector[i] = 0.0;
+    float[] vector = new float[n * 3 + 4];
+    for (int i = 0; i < n * 3; i++) vector[i] = 0.0f;
 
     for (Attribute a : oplist[0].getVisibleAttributes()) {
 
-      vector[allAttributes.indexOf(a)] = 1.0;
+      vector[allAttributes.indexOf(a)] = 1.0f;
     }
 
     for (Attribute a : oplist[1].getVisibleAttributes()) {
 
-      vector[allAttributes.indexOf(a) + n] = 1.0;
+      vector[allAttributes.indexOf(a) + n] = 1.0f;
     }
 
     if (queryGraphFeatures) {
       for (Attribute a : oplist[3].getVisibleAttributes()) {
 
         if (selectivityScaling) vector[allAttributes.indexOf(a) + 2 * n] = cardMap.get(a);
-        else vector[allAttributes.indexOf(a) + 2 * n] = 1.0;
+        else vector[allAttributes.indexOf(a) + 2 * n] = 1.0f;
       }
     }
 
@@ -102,7 +102,7 @@ public class TrainingDataPoint {
 
     vector[3 * n + 1] = gcost;
 
-    vector[3 * n + 2] = 0.0;
+    vector[3 * n + 2] = 0.0f;
 
     vector[3 * n + 3] = cost;
 
@@ -110,13 +110,9 @@ public class TrainingDataPoint {
   }
 
   public INDArray featurizeND4j(Database db, CostModel c) {
-    Double[] vector = featurize(db, c);
+    float[] vector = featurize(db, c);
     int p = vector.length;
-
-    float[] xBuffer = new float[p - 1];
-
-    for (int ind = 0; ind < vector.length - 1; ind++) xBuffer[ind] = vector[ind].floatValue();
-
+    float[] xBuffer = Arrays.copyOf(vector, p - 1);
     return Nd4j.create(xBuffer, new int[] {1, p - 1});
   }
 }

--- a/src/main/java/edu/berkeley/riselab/rlqopt/opt/quickpick/QuickPick.java
+++ b/src/main/java/edu/berkeley/riselab/rlqopt/opt/quickpick/QuickPick.java
@@ -100,15 +100,15 @@ public class QuickPick extends PlanningModule {
 
   /** Implements the QuickPick algorithm. */
   private Operator quickPick(Operator in, CostModel c) throws OperatorException {
-    double bestCost = Double.MAX_VALUE;
+    float bestCost = Float.MAX_VALUE;
     Operator bestPlan = null;
     for (int i = 1; i <= this.numTrajectories; ++i) {
-      Pair<Operator, Double> joinAndCost = rollout(new ArrayList<>(in.source), c, in, bestCost);
+      Pair<Operator, Float> joinAndCost = rollout(new ArrayList<>(in.source), c, in, bestCost);
       if (joinAndCost == null) continue;
       if (i % 50 == 0) {
         System.out.println("QuickPick: collected trajectory " + i);
       }
-      double cost = joinAndCost.right;
+      float cost = joinAndCost.right;
       if (bestPlan == null || cost < bestCost) {
         bestPlan = joinAndCost.left;
         bestCost = cost;
@@ -118,14 +118,14 @@ public class QuickPick extends PlanningModule {
   }
 
   // "relations" is a forest.
-  private double totalCost(List<Operator> relations, CostModel c) {
-    double cost = 0;
+  private float totalCost(List<Operator> relations, CostModel c) {
+    float cost = 0;
     for (Operator rel : relations) cost += costCache.getOrComputeIOEstimate(rel, c, this.name);
     return cost;
   }
 
-  private Pair<Operator, Double> rollout(
-      List<Operator> relations, final CostModel c, final Operator in, final double bestCost)
+  private Pair<Operator, Float> rollout(
+      List<Operator> relations, final CostModel c, final Operator in, final float bestCost)
       throws OperatorException {
     if (relations.size() == 1) {
       Operator finalJoin = (Operator) (relations.toArray()[0]);
@@ -168,7 +168,7 @@ public class QuickPick extends PlanningModule {
     relations.add(randomJoin);
 
     // Optimization: compute costs of "relations", if it's already larger than best, exit.
-    double totalCost = totalCost(relations, c);
+    float totalCost = totalCost(relations, c);
     if (totalCost >= bestCost) {
       return null;
     }


### PR DESCRIPTION
Changes:
+ In inference path, invoke neural net once on a batch of input
  + Also avoid expensive copies in featurizeND4j() by switching to
    featurize() then slicing out the last label in bulk
+ Change neural network input to all floats (standard in community)

This allowed my laptop (Mac pro with AVX-2 only) to match performance of a high-end server CPU
(3.0 GHz Intel Xeon Platinum 8000-series with AVX-512).

Laptop, before this change, 20/20:
+ Planning latency: {learning=14.39366491150442}
+ Planning latency: {learning=14.921567079646016}

Laptop, this change but invoke the old TDMerge(), 20/20:
+ Planning latency: {learning=45.79047076991148}
+ Planning latency: {learning=46.144710274336276}

--- To show quality is the same:

(EC2) Quality for 20/20; This change:
Improvement: {learning=15.4748217778106, left-deep=15.4748217778106, quickpick-1000=17.35624017722146}
Planning latency: {learning=11.464194350000001, left-deep=5.482218899999999, quickpick-1000=18.7576865}

(EC2) Quality for 20/20; Before (git stash):
Improvement: {learning=15.4748217778106, left-deep=15.4748217778106, nopt=-Infinity, quickpick-1000=17.35624017722146}
Planning latency: {learning=13.776011500000001, left-deep=7.5223848, nopt=3.712500000000001E-4, quickpick-1000=18.0923508}